### PR TITLE
refactor(handler): improve handler

### DIFF
--- a/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
+++ b/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
@@ -29,6 +29,6 @@
     "followers": 18,
     "following": 10,
     "created_at": "2012-12-26T18:17:53Z",
-    "updated_at": "2017-11-18T17:03:42Z"
+    "updated_at": "2018-01-05T15:04:25Z"
   }
 ]

--- a/.emdaer/README.emdaer.md
+++ b/.emdaer/README.emdaer.md
@@ -44,7 +44,7 @@ To start with, let's just look at the simplest example:
 const { Handler } = require('lambda-patterns');
 
 module.exports = {
-  yourHandler: Handler.create(event => ({
+  yourHandler: Handler.create({ event } => ({
     statusCode: 200,
     body: JSON.stringify({
       message: 'This handler was created with lambda-patterns!',
@@ -53,6 +53,33 @@ module.exports = {
   })),
 };
 ```
+
+#### Cold start detection
+
+Cold starts are detected with each invocation by taking advantage of the shared require cache between lambda invocations in the same container. The detection takes place in the `init()` step. The result is stored in the `isColdStart` boolean property on the handler. This allows you to alter behavior for cold starts only. For example, you might want to enable profiling only for cold starts or log a message to better understand the impact of cold starts to your application.
+
+```javascript
+// ./handler.js
+
+const { Handler } = require('lambda-patterns');
+
+module.exports = {
+  yourHandler: Handler.create(handler => {
+    if (handler.isColdStart) {
+      console.log('Cold start!');
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'This handler was created with lambda-patterns!',
+        input: handler.event,
+      }),
+    }
+  }),
+};
+```
+
 
 #### Enable profiling
 
@@ -75,14 +102,19 @@ class MyHandler extends Handler {
 
 module.exports = {
   yourHandler: MyHandler.create(
-    event => ({
+    { event } => ({
       statusCode: 200,
       body: JSON.stringify({
         message: 'This handler was created with lambda-patterns!',
         input: event,
       }),
     }),
-    { enableProfiling: true }
+    // shouldProfile is a function which receives the handler instance as its
+    // only argument and returns either true or false to indicate whether
+    // profiling data should be collected for the invocation. By default,
+    // profiling is always disabled. In this example we are using the handler's
+    // cold start detection to enable profiling only for cold starts.
+    { shouldProfile: handler => handler.isColdStart }
   ),
 };
 ```

--- a/.emdaer/README.emdaer.md
+++ b/.emdaer/README.emdaer.md
@@ -44,7 +44,7 @@ To start with, let's just look at the simplest example:
 const { Handler } = require('lambda-patterns');
 
 module.exports = {
-  yourHandler: Handler.create({ event } => ({
+  yourHandler: Handler.create(({ event }) => ({
     statusCode: 200,
     body: JSON.stringify({
       message: 'This handler was created with lambda-patterns!',
@@ -102,7 +102,7 @@ class MyHandler extends Handler {
 
 module.exports = {
   yourHandler: MyHandler.create(
-    { event } => ({
+    ({ event }) => ({
       statusCode: 200,
       body: JSON.stringify({
         message: 'This handler was created with lambda-patterns!',

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __coverage__
 node_modules
+.vscode

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -15,6 +15,10 @@
   * [process](#process)
   * [cleanup](#cleanup)
   * [respond](#respond)
+  * [startProfiling](#startprofiling)
+  * [stopProfiling](#stopprofiling)
+  * [always](#always)
+  * [never](#never)
   * [defaultOptions](#defaultoptions)
   * [create](#create)
 
@@ -39,7 +43,7 @@ Constructs a handler.
 
 -   `processor` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** A function responsible for processing the handler event.
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** An object containing options which modify the behavior of the handler. (optional, default `{}`)
-    -   `options.enableProfiling` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** See Handler.create for detailed description. (optional, default `false`)
+    -   `options.shouldProfile` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** See Handler.create for detailed description. (optional, default `Handler.never`)
     -   `options.waitForEventLoop` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** See Handler.create for detailed description. (optional, default `true`)
 
 ### invoke
@@ -79,6 +83,28 @@ Handle the response.
 -   `error` **[Error](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)** The error passed from the handler process.
 -   `response` **any** The response from the handler process.
 
+### startProfiling
+
+Start profiling.
+
+### stopProfiling
+
+Stop profiling.
+
+### always
+
+A utility method which always returns true.
+
+Returns **any** Boolean
+  Always returns true.
+
+### never
+
+A utility method which always returns false.
+
+Returns **any** Boolean
+  Always returns false.
+
 ### defaultOptions
 
 ### create
@@ -90,11 +116,13 @@ This can be used when defining the handler like this:
 
 **Parameters**
 
--   `processor` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** A function responsible for processing the handler event.
+-   `processor` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** A function responsible for processing the primary task of the lambda. It
+      receives the handler instance as an argument.
 -   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** An object containing options which modify the behavior of the handler. (optional, default `{}`)
-    -   `options.enableProfiling` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Specify whether profiling data should be collected for the handler
-          invocation.  WARNING: Enabling profiling will impact performance. You should usually
-          not enable this feature on production. (optional, default `false`)
+    -   `options.shouldProfile` **[Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function)** Provide a function which specifies whether profiling data should be
+          collected for the handler invocation. Defaults to Handler.never which
+          always returns false.  WARNING: Enabling profiling will impact performance. You should usually
+          not enable this feature on production. (optional, default `Handler.never`)
     -   `options.waitForEventLoop` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Specify whether the lambda process should be frozen immediately upon
           callback invocation.  WARNING: Changing this option can result in unexpected behavior and bugs
           that are difficult to track down. Only set this to false if you are

--- a/lib/Handler.js
+++ b/lib/Handler.js
@@ -1,7 +1,29 @@
+let isColdStart = true;
+
 /**
  * Provides common functionality for lambda handlers.
  */
 class Handler {
+  /**
+   * A utility method which always returns true.
+   *
+   * @returns Boolean
+   *   Always returns true.
+   */
+  static always() {
+    return true;
+  }
+
+  /**
+   * A utility method which always returns false.
+   *
+   * @returns Boolean
+   *   Always returns false.
+   */
+  static never() {
+    return false;
+  }
+
   /**
    * @type {Object}
    *   The default options for the constructor.
@@ -9,7 +31,7 @@ class Handler {
    */
   static get defaultOptions() {
     return {
-      enableProfiling: false,
+      shouldProfile: this.never,
       waitForEventLoop: true,
     };
   }
@@ -32,12 +54,14 @@ class Handler {
    * };
    *
    * @param {Function} processor
-   *   A function responsible for processing the handler event.
+   *   A function responsible for processing the primary task of the lambda. It
+   *   receives the handler instance as an argument.
    * @param {Object} options
    *   An object containing options which modify the behavior of the handler.
-   * @param {Boolean} [options.enableProfiling=false]
-   *   Specify whether profiling data should be collected for the handler
-   *   invocation.
+   * @param {Function} [options.shouldProfile=Handler.never]
+   *   Provide a function which specifies whether profiling data should be
+   *   collected for the handler invocation. Defaults to Handler.never which
+   *   always returns false.
    *
    *   WARNING: Enabling profiling will impact performance. You should usually
    *   not enable this feature on production.
@@ -59,8 +83,7 @@ class Handler {
    * @static
    */
   static create(processor, options = {}) {
-    const handler = new this(processor, options);
-    return (...args) => handler.invoke(...args);
+    return (...args) => new this(processor, options).invoke(...args);
   }
 
   /**
@@ -70,7 +93,7 @@ class Handler {
    *   A function responsible for processing the handler event.
    * @param {Object} options
    *   An object containing options which modify the behavior of the handler.
-   * @param {Boolean} [options.enableProfiling=false]
+   * @param {Function} [options.shouldProfile=Handler.never]
    *   See Handler.create for detailed description.
    * @param {Boolean} [options.waitForEventLoop=true]
    *   See Handler.create for detailed description.
@@ -83,17 +106,6 @@ class Handler {
     this.processor = processor;
 
     this.options = Object.assign({}, this.constructor.defaultOptions, options);
-
-    // We only require the profiler if we need it to ensure as little impact as
-    // possible when profiling is disabled.
-    if (this.options.enableProfiling) {
-      if (typeof this.constructor.profiler === 'undefined') {
-        this.constructor.profiler = require('v8-profiler-lambda'); // eslint-disable-line global-require
-      }
-      if (typeof this.constructor.deflateSync === 'undefined') {
-        this.constructor.deflateSync = require('zlib').deflateSync; // eslint-disable-line global-require
-      }
-    }
   }
 
   /**
@@ -130,8 +142,12 @@ class Handler {
    * Perform initialization tasks upon handler invocation.
    */
   init() {
-    if (this.options.enableProfiling) {
-      this.constructor.profiler.startProfiling(this.context.awsRequestId);
+    this.isColdStart = isColdStart;
+    isColdStart = false;
+
+    this.profilingEnabled = this.options.shouldProfile(this);
+    if (this.profilingEnabled) {
+      this.startProfiling();
     }
 
     if (this.options.waitForEventLoop === false) {
@@ -148,17 +164,15 @@ class Handler {
    *   which resolves with it.
    */
   process() {
-    return this.processor(this.event, this.context);
+    return this.processor(this);
   }
 
   /**
    * Perform cleanup tasks before responding.
    */
   cleanup() {
-    if (this.options.enableProfiling) {
-      const profile = this.constructor.profiler.stopProfiling(this.context.awsRequestId);
-      this.profile = this.constructor.deflateSync(JSON.stringify(profile)).toString('base64');
-      profile.delete();
+    if (this.profilingEnabled) {
+      this.stopProfiling();
     }
   }
 
@@ -172,6 +186,32 @@ class Handler {
    */
   respond(error, response) {
     this.callback(error, response);
+  }
+
+  /**
+   * Start profiling.
+   */
+  startProfiling() {
+    // We only require the profiler if we need it to ensure as little impact as
+    // possible when profiling is disabled.
+    if (typeof this.constructor.profiler === 'undefined') {
+      this.constructor.profiler = require('v8-profiler-lambda'); // eslint-disable-line global-require
+    }
+    if (typeof this.constructor.deflateSync === 'undefined') {
+      this.constructor.deflateSync = require('zlib').deflateSync; // eslint-disable-line global-require
+    }
+
+    // Start profiling.
+    this.constructor.profiler.startProfiling(this.context.awsRequestId);
+  }
+
+  /**
+   * Stop profiling.
+   */
+  stopProfiling() {
+    const profile = this.constructor.profiler.stopProfiling(this.context.awsRequestId);
+    this.profile = this.constructor.deflateSync(JSON.stringify(profile)).toString('base64');
+    profile.delete();
   }
 }
 

--- a/lib/Handler.js
+++ b/lib/Handler.js
@@ -146,9 +146,7 @@ class Handler {
     isColdStart = false;
 
     this.profilingEnabled = this.options.shouldProfile(this);
-    if (this.profilingEnabled) {
-      this.startProfiling();
-    }
+    this.startProfiling();
 
     if (this.options.waitForEventLoop === false) {
       // eslint-disable-next-line no-param-reassign
@@ -171,9 +169,7 @@ class Handler {
    * Perform cleanup tasks before responding.
    */
   cleanup() {
-    if (this.profilingEnabled) {
-      this.stopProfiling();
-    }
+    this.stopProfiling();
   }
 
   /**
@@ -192,6 +188,11 @@ class Handler {
    * Start profiling.
    */
   startProfiling() {
+    if (!this.profilingEnabled) {
+      // #donothing
+      return;
+    }
+
     // We only require the profiler if we need it to ensure as little impact as
     // possible when profiling is disabled.
     if (typeof this.constructor.profiler === 'undefined') {
@@ -209,6 +210,11 @@ class Handler {
    * Stop profiling.
    */
   stopProfiling() {
+    if (!this.profilingEnabled) {
+      // #donothing
+      return;
+    }
+
     const profile = this.constructor.profiler.stopProfiling(this.context.awsRequestId);
     this.profile = this.constructor.deflateSync(JSON.stringify(profile)).toString('base64');
     profile.delete();

--- a/lib/Handler.js
+++ b/lib/Handler.js
@@ -195,10 +195,10 @@ class Handler {
 
     // We only require the profiler if we need it to ensure as little impact as
     // possible when profiling is disabled.
-    if (typeof this.constructor.profiler === 'undefined') {
+    if (!this.constructor.profiler) {
       this.constructor.profiler = require('v8-profiler-lambda'); // eslint-disable-line global-require
     }
-    if (typeof this.constructor.deflateSync === 'undefined') {
+    if (!this.constructor.deflateSync) {
       this.constructor.deflateSync = require('zlib').deflateSync; // eslint-disable-line global-require
     }
 


### PR DESCRIPTION
BREAKING CHANGES:
- The handler processor function now takes the handler instance as an
argument rather than event and context.
- The enableProfiling boolean option was replaced with the shouldProfile
option which is a function receiving the handler instance as an argument
and returning a boolean indicating whether profiling should be enabled.
- A new handler instance is now created with every lambda invocation.
Previously, one instance would be shared between invocations even though
invocation data like event and context were overwritten with each
invocation.

NEW FEATURES:
- Cold start detection was added.