### PR TITLE
fix(package): move flow-aws-lambda to prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-flowtype": "^2.46.1",
     "eslint-plugin-import": "^2.8.0",
-    "flow-aws-lambda": "^1.0.2",
     "flow-bin": "^0.66.0",
     "flow-copy-source": "^1.3.0",
     "flow-remove-types": "^1.2.3",
@@ -43,6 +42,7 @@
     "semantic-release-conventional-commits": "^1.2.0"
   },
   "dependencies": {
+    "flow-aws-lambda": "^1.0.2",
     "percentage-incrementor": "^1.0.0",
     "v8-profiler-lambda": "iopipe/v8-profiler-lambda"
   },


### PR DESCRIPTION
Packages that depend on this one will fail flow checking because the
production version is installed, leaving behind "flow-aws-lambda".